### PR TITLE
Fixed licensing mistake. License is GPL-3.0 only.

### DIFF
--- a/docs/copyright.rst
+++ b/docs/copyright.rst
@@ -7,15 +7,14 @@ Copyright
     Copyright (C) 2015-2016 Robin Schneider <ypid@riseup.net>
     Copyright (C) 2014-2016 DebOps Project http://debops.org/
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program. If not, see http://www.gnu.org/licenses/


### PR DESCRIPTION
Other roles are licensed under GPL-3.0 (version 3 only) which I agree
with as the maintainers should approve new versions for the license
first.

I wrongly put the role under GPL-3.0+ which includes any later version
of the GPL. This mistake is fixed by this commit. Only @drybjed and me
have touched the role since I explicitly put it under GPL-3.0+.
I hereby give my approval to this license change.

License identifiers used as defined by https://spdx.org/licenses/

Related to https://github.com/debops/ansible-apt/pull/59